### PR TITLE
further cleaned up PETSc instructions

### DIFF
--- a/clusterSetup/GreatlakesSetup.rst
+++ b/clusterSetup/GreatlakesSetup.rst
@@ -69,32 +69,16 @@ Below is an example Batch script for Great Lakes.
 .. code-block:: bash
 
    #!/bin/bash
-   # The interpreter used to execute the script:
-   # "SBATCH" directives that convey submission options:
-   ##### The name of the job
-   #SBATCH --job-name=Jobname
-   ##### Email address
-   #SBATCH --mail-user=$USER@umich.edu
-   ##### When to send e-mail: pick from NONE, BEGIN, END, FAIL, REQUEUE, ALL
-   #SBATCH --mail-type=BEGIN,END,FAIL
-   ##### Resources for your job
-   # number of physical nodes
-   #SBATCH --nodes=1
-   # number of task per nodes (number of CPU-cores per node)
-   #SBATCH --ntasks-per-node=36
-   # memory per CPU core
-   #SBATCH --mem-per-cpu=5GB
-   ##### Maximum amount of time the job will be allowed to run
-   ##### Recommended formats: MM:SS, HH:MM:SS, DD-HH:MM
-   #SBATCH --time=100:00:00
-   ##### The resource account; who pays
-   #SBATCH --account=jrram1
-   #SBATCH --partition=standard
-   ##### Output path
-   #SBATCH --output=/home/%u/%x-%j.log
-   ########## End of preamble! #########################################
-   # No need to “cd”. Slurm starts the job in the submission directory.
-   #####################################################################
+   #SBATCH --job-name=<job-name>        # unique identifier for the job
+   #SBATCH --mail-user=$USER@umich.edu  # email address to send notification
+   #SBATCH --mail-type=BEGIN,END,FAIL   # when to notify, pick from NONE, BEGIN, END, FAIL, REQUEUE, ALL
+   #SBATCH --nodes=1                    # number of nodes
+   #SBATCH --ntasks-per-node=36         # number of CPU-cores per node, max is 36 for GL
+   #SBATCH --mem-per-cpu=5GB            # memory per CPU core
+   #SBATCH --time=100:00:00             # Recommended formats: MM:SS, HH:MM:SS, DD-HH:MM
+   #SBATCH --account=jrram1             # the billing account
+   #SBATCH --partition=standard         # typically either standard or debug
+
    source ~/.bashrc
    # The application(s) to execute along with its input arguments and options:
    mpirun -np 36 python opt.py

--- a/clusterSetup/GreatlakesSetup.rst
+++ b/clusterSetup/GreatlakesSetup.rst
@@ -15,10 +15,8 @@ and get access to the cluster. GreatLakes requires an on-campus connection, whic
 Great Lakes users manual is at:
 https://arc-ts.umich.edu/greatlakes/
 
-.. note::
-    It is known: "python2.7-anaconda/2019.03" works.
-    If you want to run cases using multiple nodes, you will have to use a newer version of openmpi (openmpi/3.1.4), and you need specific forks for some reops to work with the newer openmpi. 
-    For example, pygeo (https://github.com/nbons/pygeo), idwarp (https://github.com/camader/idwarp), adflow (https://github.com/camader/adflow).
+A ``gcc``-based installation is recommended. The compiler/MPI versions can be found in the ``.bashrc`` below.
+Intel-based installs are possible, with ``intel/18.0.5`` and ``impi/2018.4.274``. However, the setup is significantly more complicated.
 
 Example .bashrc
 ---------------
@@ -28,43 +26,40 @@ home directory on Great Lakes.
 
 .. code-block:: bash
 
-   # .bashrc                                                                
+   # .bashrc
 
-   # Source global definitions                       
+   # Source global definitions
    if [ -f /etc/bashrc ]; then
         . /etc/bashrc
    fi
 
-   module load python2.7-anaconda/2019.03                                                                                                       
-   module load gcc/4.8.5                                                                                                           
-   module load openmpi/1.10.7
-   # if you want to use multiple nodes, use 3.1.4
-   # module load openmpi/3.1.4
+   module load python2.7-anaconda/2019.03
+   module load gcc/4.8.5
+   module load openmpi/3.1.4
    module load cmake/3.13.2
 
 
    # add the repos directory to your python path so that the mdolab modules will be available
    export PYTHONPATH=$PYTHONPATH:$HOME/repos/
 
-   # CGNS 
+   # CGNS
    # Follow the 3rd party package installation tutorial to add the correct PATH
-   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/packages/cgnslib_3.2.1/src
-   # CGNS 3.3.0
-   # export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/packages/CGNS-3.3.0/src
+   export CGNS_HOME=$HOME/packages/CGNS-3.3.0
+   export PATH=$PATH:$CGNS_HOME/bin
+   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CGNS_HOME/lib
 
 
-   # Petsc
+   # PETSc
    export PETSC_DIR=${HOME}/packages/<petsc-version>
    export PETSC_ARCH=real-opt
    export PATH=${PATH}:${HOME}/repos/tacs_orig/extern/f5totec
    export PATH=$PATH:$HOME/repos/cgnsutilities/bin
 
    # User specific aliases and functions
-   alias j='squeue -u uniqname'
-   alias scr='cd /scratch/jrram_root/jrram/uniqname'
+   alias j='squeue -u <uniqname>'
+   alias scr='cd /scratch/jrram_root/jrram/<uniqname>'
 
 This file starts by specifying the preset modules you want to load.
-On GreatLakes, if you want to use openmpi/1.10.7, you have to use gcc.
 This is followed by a section setting the environment variables to allow the use of the MDOlab software.
 The last portion of the file specifies a series of aliases to make some standard operations easier.
 
@@ -75,41 +70,43 @@ Below is an example Batch script for Great Lakes.
 
 .. code-block:: bash
 
-   #!/bin/bash                                                                                                                       
-   # The interpreter used to execute the script:                                                                                     
-   # "SBATCH" directives that convey submission options:                                                                             
-   ##### The name of the job                                                                                                         
+   #!/bin/bash
+   # The interpreter used to execute the script:
+   # "SBATCH" directives that convey submission options:
+   ##### The name of the job
    #SBATCH --job-name=Jobname
    ##### Email address
-   #SBATCH --mail-user=uniqname@umich.edu                                                                                               
-   ##### When to send e-mail: pick from NONE, BEGIN, END, FAIL, REQUEUE, ALL                                                         
-   #SBATCH --mail-type=BEGIN,END,FAIL                                                                                                
-   ##### Resources for your job                                                                                                      
-   # number of physical nodes                                                                                                        
-   #SBATCH --nodes=1                                                                                                                 
-   # number of task per nodes (number of CPU-cores per node)                                                                         
-   #SBATCH --ntasks-per-node=36                                                                                                      
-   # memory per CPU core                                                                                                             
-   #SBATCH --mem-per-cpu=5GB                                                                                                        
-   ##### Maximum amount of time the job will be allowed to run                                                                       
-   ##### Recommended formats: MM:SS, HH:MM:SS, DD-HH:MM                                                                              
-   #SBATCH --time=100:00:00                                                                                                          
-   ##### The resource account; who pays                                                                                              
-   #SBATCH --account=jrram1    
+   #SBATCH --mail-user=<uniqname>@umich.edu
+   ##### When to send e-mail: pick from NONE, BEGIN, END, FAIL, REQUEUE, ALL
+   #SBATCH --mail-type=BEGIN,END,FAIL
+   ##### Resources for your job
+   # number of physical nodes
+   #SBATCH --nodes=1
+   # number of task per nodes (number of CPU-cores per node)
+   #SBATCH --ntasks-per-node=36
+   # memory per CPU core
+   #SBATCH --mem-per-cpu=5GB
+   ##### Maximum amount of time the job will be allowed to run
+   ##### Recommended formats: MM:SS, HH:MM:SS, DD-HH:MM
+   #SBATCH --time=100:00:00
+   ##### The resource account; who pays
+   #SBATCH --account=jrram1
    #SBATCH --partition=standard
    ##### Output path
-   #SBATCH --output=/home/%u/%x-%j.log                                                                                                       
-   ########## End of preamble! #########################################                                                             
-   # No need to “cd”. Slurm starts the job in the submission directory.                                                              
-   #####################################################################  
-   source ~/.bashrc                                                           
-   # The application(s) to execute along with its input arguments and options:                                                       
-   mpirun -np 36 python opt.py 
+   #SBATCH --output=/home/%u/%x-%j.log
+   ########## End of preamble! #########################################
+   # No need to “cd”. Slurm starts the job in the submission directory.
+   #####################################################################
+   source ~/.bashrc
+   # The application(s) to execute along with its input arguments and options:
+   mpirun -np 36 python opt.py
 
 .. note::
-    1. By default Slurm does not source the files ``~./bashrc`` or ``~/.profile``.
+   #. By default Slurm does not source the files ``~./bashrc`` or ``~/.profile``.
 
-    2. You can use any of ``srun``, ``mpirun`` or ``mpiexec`` commands to start your MPI job. In most cases, ``mpirun`` will work correctly with OpenMPI. With some old version of OpenMPI, ``srun`` will fail.
+   #. You can use any of ``srun``, ``mpirun`` or ``mpiexec`` commands to start your MPI job. In most cases, ``mpirun`` will work correctly with OpenMPI. With some old version of OpenMPI, ``srun`` will fail.
+
+   #. ``srun`` seems to be much faster than ``mpirun`` using an Intel-based installation.
 
 Partitions
 ----------
@@ -118,8 +115,8 @@ Great Lakes currently has the following partitions: standard, large memory, GPU,
 Typically, we will only have access to standard partition.
 There is no need to specify the architecture the same way as in flux.
 
-.. list-table:: 
-    :widths: 30 20 20 20 
+.. list-table::
+    :widths: 30 20 20 20
     :header-rows: 1
 
     * - Node type
@@ -132,11 +129,15 @@ There is no need to specify the architecture the same way as in flux.
       - 192
       - 380
 
+A separate debug queue is also available, which can be requested via ``--partition=debug``.
+It's exactly the same as the standard queue, but with a limit of 8 processors and 4 hours wall time, as well
+as only one job per user at any given time.
+The debug queue itself has higher priority, so it can be useful when the standard queue is packed.
 
 
 Job Submission and Monitoring
 -----------------------------
 
-Jobs are submitted with ``sbatch batch_script``, and cancelled with ``scancel jobid``, where ``jobid`` can be found with ``squeue -u uniqname``. 
+Jobs are submitted with ``sbatch batch_script``, and cancelled with ``scancel jobid``, where ``jobid`` can be found with ``squeue -u <uniqname>``. 
 To check the estimated starting time for your job, type ``squeue -j <job ID> --start``.
-Interactive jobs may be useful for debugging purposes, and they can be requested with the ``srun --nodes=2 --ntasks-per-node=4 --mem-per-cpu=1GB --cpus-per-task=1 --time=1:00:00 --pty /bin/bash``. 
+Interactive jobs may be useful for debugging purposes, and they can be requested with the ``srun --nodes=2 --ntasks-per-node=4 --mem-per-cpu=1GB --cpus-per-task=1 --time=1:00:00 --pty /bin/bash``.

--- a/clusterSetup/GreatlakesSetup.rst
+++ b/clusterSetup/GreatlakesSetup.rst
@@ -75,7 +75,7 @@ Below is an example Batch script for Great Lakes.
    #SBATCH --nodes=1                    # number of nodes
    #SBATCH --ntasks-per-node=36         # number of CPU-cores per node, max is 36 for GL
    #SBATCH --mem-per-cpu=5GB            # memory per CPU core
-   #SBATCH --time=100:00:00             # Recommended formats: MM:SS, HH:MM:SS, DD-HH:MM
+   #SBATCH --time=100:00:00             # recommended formats: MM:SS, HH:MM:SS, DD-HH:MM
    #SBATCH --account=jrram1             # the billing account
    #SBATCH --partition=standard         # typically either standard or debug
 
@@ -116,10 +116,20 @@ It's exactly the same as the standard queue, but with a limit of 8 processors an
 as only one job per user at any given time.
 The debug queue itself has higher priority, so it can be useful when the standard queue is packed.
 
+Interactive Jobs
+----------------
+Interactive jobs are jobs where you get access to the terminal, such that you can run tasks interactively.
+It would be exactly the same as if you were running jobs on your local computer, except you get access to more cores and more memory.
+
+For example, an interactive job with 16 processors for one hour can be requested using::
+
+   srun --nodes=1 --ntasks-per-node=16 --mem-per-cpu=5GB --time=1:00:00 --partition standard --pty /bin/bash
+
+If the cluster is busy, using the debug queue (while staying under its resource limits) may be faster.
+Once successful, you'll be logged in to a compute node (the hostname would look something like ``gl3057``), and you can then run your code normally.
 
 Job Submission and Monitoring
 -----------------------------
 
 Jobs are submitted with ``sbatch batch_script``, and cancelled with ``scancel jobid``, where ``jobid`` can be found with ``squeue -u $USER``.
 To check the estimated starting time for your job, type ``squeue -j <job ID> --start``.
-Interactive jobs may be useful for debugging purposes, and they can be requested with the ``srun --nodes=2 --ntasks-per-node=4 --mem-per-cpu=1GB --cpus-per-task=1 --time=1:00:00 --pty /bin/bash``.

--- a/clusterSetup/GreatlakesSetup.rst
+++ b/clusterSetup/GreatlakesSetup.rst
@@ -1,8 +1,6 @@
 .. Documentation of a basic setup on the flux cluster.
    Note that the user is assumed to have already gotten an account
    setup, and has access to the login nodes on the cluster.
-   Author: C.A.(Sandy) Mader (cmader@umich.edu)
-   Edited by: 
 
 .. _Great Lakes:
 

--- a/clusterSetup/GreatlakesSetup.rst
+++ b/clusterSetup/GreatlakesSetup.rst
@@ -8,7 +8,7 @@ GreatLakes Cluster Setup
 ========================
 This guide is intended to assist users with setting up the MDOlab software
 on the UMich GreatLakes Cluster.  The user will first need to create an account
-and get access to the cluster. GreatLakes requires an on-campus connection, which can be provided by UMVPN (see :ref:`settingUpUMVPN` for setup instructions). An alternative is to first ``ssh`` into ``login.itd.umich.edu``, which does not require an on-campus connection, then from there ``ssh`` on to ``greatlakes.arc-ts.umich.edu``. It is recommended to save these commands as aliases or bash scripts for convenience. 
+and get access to the cluster. GreatLakes requires an on-campus connection, which can be provided by UMVPN (see :ref:`settingUpUMVPN` for setup instructions). An alternative is to first ``ssh`` into ``login.itd.umich.edu``, which does not require an on-campus connection, then from there ``ssh`` on to ``greatlakes.arc-ts.umich.edu``. It is recommended to save these commands as aliases or bash scripts for convenience.
 
 Great Lakes users manual is at:
 https://arc-ts.umich.edu/greatlakes/
@@ -54,8 +54,8 @@ home directory on Great Lakes.
    export PATH=$PATH:$HOME/repos/cgnsutilities/bin
 
    # User specific aliases and functions
-   alias j='squeue -u <uniqname>'
-   alias scr='cd /scratch/jrram_root/jrram/<uniqname>'
+   alias j='squeue -u $USER'
+   alias scr='cd /scratch/jrram_root/jrram/$USER'
 
 This file starts by specifying the preset modules you want to load.
 This is followed by a section setting the environment variables to allow the use of the MDOlab software.
@@ -74,7 +74,7 @@ Below is an example Batch script for Great Lakes.
    ##### The name of the job
    #SBATCH --job-name=Jobname
    ##### Email address
-   #SBATCH --mail-user=<uniqname>@umich.edu
+   #SBATCH --mail-user=$USER@umich.edu
    ##### When to send e-mail: pick from NONE, BEGIN, END, FAIL, REQUEUE, ALL
    #SBATCH --mail-type=BEGIN,END,FAIL
    ##### Resources for your job
@@ -136,6 +136,6 @@ The debug queue itself has higher priority, so it can be useful when the standar
 Job Submission and Monitoring
 -----------------------------
 
-Jobs are submitted with ``sbatch batch_script``, and cancelled with ``scancel jobid``, where ``jobid`` can be found with ``squeue -u <uniqname>``. 
+Jobs are submitted with ``sbatch batch_script``, and cancelled with ``scancel jobid``, where ``jobid`` can be found with ``squeue -u $USER``.
 To check the estimated starting time for your job, type ``squeue -j <job ID> --start``.
 Interactive jobs may be useful for debugging purposes, and they can be requested with the ``srun --nodes=2 --ntasks-per-node=4 --mem-per-cpu=1GB --cpus-per-task=1 --time=1:00:00 --pty /bin/bash``.

--- a/clusterSetup/fluxSetup.rst
+++ b/clusterSetup/fluxSetup.rst
@@ -1,8 +1,6 @@
 .. Documentation of a basic setup on the flux cluster.
    Note that the user is assumed to have already gotten an account
    setup, and has access to the login nodes on the cluster.
-   Author: C.A.(Sandy) Mader (cmader@umich.edu)
-   Edited by: 
 
 .. _flux:
 

--- a/clusterSetup/pleaidesSetup.rst
+++ b/clusterSetup/pleaidesSetup.rst
@@ -1,8 +1,6 @@
 .. Documentation of initial setup on the NASA Pleiades cluster.
    Note that the user is assumed to have already gotten an account
    setup, and has access to one of the pfe nodes on the cluster.
-   Author: David Burdette (daburdet@umich.edu)
-   Edited by: John Jasa (johnjasa@umich.edu)
 
 .. _pleiades:
 

--- a/clusterSetup/stampedeSetup.rst
+++ b/clusterSetup/stampedeSetup.rst
@@ -1,8 +1,6 @@
 .. Documentation of a basic setup on the stampede2 cluster.
    Note that the user is assumed to have already gotten an account
    setup, and has access to the login nodes on the cluster.
-   Author: C.A.(Sandy) Mader (cmader@umich.edu)
-   Edited by: Neil Wu (neilwu@umich.edu)
 
 .. _stampede2:
 

--- a/index.rst
+++ b/index.rst
@@ -40,7 +40,6 @@ Installation instructions
    installInstructions/install3rdPartyPackages
 
    clusterSetup/pleaidesSetup
-   clusterSetup/fluxSetup
    clusterSetup/GreatlakesSetup
    clusterSetup/stampedeSetup
 

--- a/installInstructions/install3rdPartyPackages.rst
+++ b/installInstructions/install3rdPartyPackages.rst
@@ -179,7 +179,7 @@ To get a list of all available options run::
 
    ./configure --help
 
-We explain the relevant flags below, but you can jump ahead to
+We explain the relevant options below, but you can jump ahead to
 :ref:`configure PETSc <configure_petsc>` and use one of the pre-set list of options there.
 
 #. **Debugging**: To compile without debugging use the switch:
@@ -332,14 +332,6 @@ Make a ``build`` directory, and call cmake from there to configure the package:
 Finally, build and install::
 
    make all install
-
-Now, for pyHyp, ADflow, pyWarp and cgnsUtilities, the required include
-flags and linking flags will be:
-
-.. code-block:: bash
-
-   CGNS_INCLUDE_FLAGS=-I$(CGNS_HOME)/include
-   CGNS_LINKER_FLAGS=-L$(CGNS_HOME)/lib -lcgns
 
 .. NOTE::
    **Optional**: To build the CGNS tools to view and edit CGNS files manually,

--- a/installInstructions/install3rdPartyPackages.rst
+++ b/installInstructions/install3rdPartyPackages.rst
@@ -6,14 +6,20 @@
 3rd Party Packages
 ==================
 .. NOTE::
-   Before trying to compile everything yourself, including all dependencies, consider using the Docker image available on Docker Hub at ``mdolab/public``.
+   Before trying to compile everything yourself, including all dependencies, consider using the ``mdolab/public`` Docker image available on `Docker Hub <https://hub.docker.com/r/mdolab/public>`_.
 
 .. _working_stacks:
 
-Working Stacks
---------------
+Supported dependency versions
+-----------------------------
 This section lists out the dependency versions that have been verified to work with specific code versions.
 Here ``version`` refers to the code version, and ``tag`` refers to the Docker image tag.
+If you are using the latest code from GitHub, then please use the row that contains the latest ``version``.
+
+.. IMPORTANT::
+   Although the code may work with other dependency versions (for example numpy and scipy requirements are not
+   strict), we only test code against the dependency versions listed below. Therefore, if you choose to use
+   a different dependency version, then you are essentially on your own.
 
 .. list-table::
    :header-rows: 1
@@ -362,9 +368,9 @@ Python Packages
 ---------------
 
 .. IMPORTANT::
-   MDOlab tools have been tested to work with python2.
-   The MDOlab is in the process of migrating to python3;
-   support for python2 will be dropped before python2 EOL (January 2020).
+   MDOlab tools have been tested to work with python 2.
+   The MDOlab is in the process of migrating to python 3;
+   however we will continue to support python 2 for the forseeable future.
 
 In this guide, python packages are installed using ``pip``.
 Other methods, such as from source or using ``conda``, will also work.
@@ -398,6 +404,10 @@ It is installed with::
 
    pip install numpy==1.16.4 --user --no-cache
 
+On a ``conda``-based system, it is recommended to use ``conda`` to install numpy and scipy::
+
+   conda install numpy==1.16.4
+
 `Scipy <http://scipy.org/>`_
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Scipy is required for several packages including :ref:`pyoptsparse`, :ref:`pygeo` and certain
@@ -405,6 +415,10 @@ functionality in pytacs and :ref:`pyspline`.
 It is installed with::
 
    pip install scipy==1.2.1 --user --no-cache
+
+On a ``conda``-based system, it is recommended to use ``conda`` to install numpy and scipy::
+
+   conda install scipy==1.2.1
 
 .. note::
    On a cluster, most likely numpy and scipy will already be

--- a/installInstructions/install3rdPartyPackages.rst
+++ b/installInstructions/install3rdPartyPackages.rst
@@ -475,11 +475,7 @@ Advanced install (Multiple PETSc architectures needed)
 extract the latest version (the major version should be consistent with
 the PETSc version installed, i.e., 3.11.0 here)::
 
-$ tar -xzf petsc4py-3.11.0.tar.gz
-
-Due to the fact that we use a very old version of petsc4py (and potentially together with anaconda), before installing, issue the command::
-
-$ export LDSHARED=-shared
+   $ tar -xzf petsc4py-3.11.0.tar.gz
 
 From the petsc4py-3.11.0 directory do a user-space install::
 

--- a/installInstructions/install3rdPartyPackages.rst
+++ b/installInstructions/install3rdPartyPackages.rst
@@ -66,7 +66,7 @@ Common Prerequisites
 --------------------
 If they're not available already, common prerequisites can be installed directly from a Debian repository::
 
-   sudo apt-get install python-dev gfortran valgrind cmake
+   sudo apt-get install python-dev gfortran valgrind cmake libblas-dev liblapack-dev
 
 The packages are required by many of the packages installed later.
 On a cluster, check the output of ``module avail`` to see what has already been installed.
@@ -180,7 +180,7 @@ We explain the relevant flags below, but you can jump ahead to
 
    .. code-block:: bash
 
-      --with-debugging=no
+      --with-debugging=0
 
    If you are doing any code development which uses PETSc,
    it is *highly* recommended to use debugging.
@@ -193,17 +193,6 @@ We explain the relevant flags below, but you can jump ahead to
 
       --COPTFLAGS=-O3 --CXXOPTFLAGS=-O3 --FOPTFLAGS=-O3
 
-#. **BLAS and LAPACK**: Linear algebra packages.
-
-   If you do not have BLAS and LAPACK installed you can include
-   the following in the configure:
-
-   .. code-block:: bash
-
-      --download-fblaslapack=1
-
-   This is typically not necessary on HPC systems as they tend to provide optimized packages, typically through MKL.
-
 #. **METIS and ParMETIS**: partitioning packages
 
    If you do not have METIS and ParMETIS installed, include the following line:
@@ -211,6 +200,12 @@ We explain the relevant flags below, but you can jump ahead to
    .. code-block:: bash
 
       --download-metis=yes --download-parmetis=yes
+
+   If they are already installed, you can simply supply the installation directories:
+
+   .. code-block:: bash
+
+      --with-metis --with-metis-dir=<metis-dir> --with-parmetis --with-parmetis-dir=<parmetis-dir>
 
 #. **Complex build**: partitioning packages
 
@@ -225,7 +220,7 @@ We explain the relevant flags below, but you can jump ahead to
 
    .. code-block:: bash
 
-      --with-shared-libraries --download-superlu_dist=yes --with-fortran-interfaces=1 --with-cxx-dialect=C++11
+      --with-shared-libraries --download-superlu_dist=yes --with-fortran-bindings=1 --with-cxx-dialect=C++11
 
    Specifically, :ref:`pyWarp` uses the ``superlu_dist``.
 
@@ -238,45 +233,24 @@ Putting these options together, some complete examples of configuring PETSc are:
 
    .. code-block:: bash
 
-      ./configure --PETSC_ARCH=$PETSC_ARCH --with-scalar-type=real --with-debugging=yes --with-mpi-dir=$MPI_INSTALL_DIR \
-         --download-fblaslapack=yes --download-metis=yes --download-parmetis=yes --download-superlu_dist=yes \
-         --with-shared-libraries=yes --with-fortran-interfaces=yes --with-cxx-dialect=C++11
+      ./configure --PETSC_ARCH=$PETSC_ARCH --with-scalar-type=real --with-debugging=1 --with-mpi-dir=$MPI_INSTALL_DIR \
+         --download-metis=yes --download-parmetis=yes --download-superlu_dist=yes \
+         --with-shared-libraries=yes --with-fortran-bindings=1 --with-cxx-dialect=C++11
 
 #. Debug complex build (``$PETSC_ARCH=complex-debug``):
 
    .. code-block:: bash
 
-      ./configure --PETSC_ARCH=$PETSC_ARCH --with-scalar-type=complex --with-debugging=yes --with-mpi-dir=$MPI_INSTALL_DIR \
-         --download-fblaslapack=yes --download-metis=yes --download-parmetis=yes --download-superlu_dist=yes \
-         --with-shared-libraries=yes --with-fortran-interfaces=yes --with-cxx-dialect=C++11
+      ./configure --PETSC_ARCH=$PETSC_ARCH --with-scalar-type=complex --with-debugging=1 --with-mpi-dir=$MPI_INSTALL_DIR \
+         --download-metis=yes --download-parmetis=yes --download-superlu_dist=yes \
+         --with-shared-libraries=yes --with-fortran-bindings=1 --with-cxx-dialect=C++11
 
-#. Optimized real build on a cluster with existing MPI (``$PETSC_ARCH=real-opt``). (For production runs on a cluster you *MUST* use an optimized build.):
+#. Optimized real build on a cluster with existing MPI (``$PETSC_ARCH=real-opt``):
 
    .. code-block:: bash
 
       ./configure --with-shared-libraries --download-superlu_dist --download-parmetis=yes --download-metis=yes \
-         --with-fortran-interfaces=1 --with-debugging=no --with-scalar-type=real --PETSC_ARCH=$PETSC_ARCH --with-cxx-dialect=C++11
-
-#. Optimized build, referencing an existing parmetis/metis and hdf5 installation
-   (using the ``$HOME/opt`` installation directory convention):
-
-   .. code-block:: bash
-
-      ./configure --prefix=$HOME/opt/petsc/3.7.7/hdf5-1.8.21/OpenMPI-1.10.7/GCC-7.3.0 \
-         --with-shared-libraries --PETSC_ARCH=linux-gnu-real-opt --with-debugging=no \
-         --download-fblaslapack=1 --download-superlu_dist=1 \
-            --with-metis    --with-metis-dir=$HOME/opt/parmetis/4.0.3/OpenMPI-1.10.7/GCC-7.3.0 \
-         --with-parmetis --with-parmetis-dir=$HOME/opt/parmetis/4.0.3/OpenMPI-1.10.7/GCC-7.3.0 \
-         --with-hdf5 --with-hdf5-dir=$HOME/opt/hdf5/1.8.21/OpenMPI-1.10.7/GCC-7.3.0 \
-         --with-fortran-interfaces
-
-#. Debug build which downloads and installs OpenMPI also (not recommended):
-
-   .. code-block:: bash
-
-      ./configure --with-shared-libraries --download-superlu_dist --download-parmetis --download-metis \
-         --with-fortran-interfaces --with-debugging=yes --with-scalar-type=real --download-fblaslapack \
-         --PETSC_ARCH=$PETSC_ARCH --download-openmpi --with-cc=gcc --with-cxx=g++ --with-fc=gfortran
+         --with-fortran-bindings=1 --with-debugging=0 --with-scalar-type=real --PETSC_ARCH=$PETSC_ARCH --with-cxx-dialect=C++11
 
 After the configuration step, PETSc must be built. This is accomplished with the command provided at the end of the configure script. It will look something like below (the PETSc version should be consistent with the version being installed.)::
 
@@ -490,7 +464,7 @@ Simple install with pip
 
 It is installed with::
 
-   pip install --user --no-cache petsc4py==3.7.0
+   pip install --user --no-cache petsc4py==3.11.0
 
 Advanced install (Multiple PETSc architectures needed)
 ******************************************************
@@ -499,15 +473,15 @@ Advanced install (Multiple PETSc architectures needed)
 
 `Download <https://bitbucket.org/petsc/petsc4py/downloads>`__ the source code and
 extract the latest version (the major version should be consistent with
-the PETSc version installed, i.e., 3.7.0 here)::
+the PETSc version installed, i.e., 3.11.0 here)::
 
-$ tar -xzf petsc4py-3.7.0.tar.gz
+$ tar -xzf petsc4py-3.11.0.tar.gz
 
 Due to the fact that we use a very old version of petsc4py (and potentially together with anaconda), before installing, issue the command::
 
 $ export LDSHARED=-shared
 
-From the petsc4py-3.7.0 directory do a user-space install::
+From the petsc4py-3.11.0 directory do a user-space install::
 
 $ python setup.py install --user
 

--- a/installInstructions/install3rdPartyPackages.rst
+++ b/installInstructions/install3rdPartyPackages.rst
@@ -400,16 +400,11 @@ It is installed with::
 
 `Scipy <http://scipy.org/>`_
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. IMPORTANT::
-   The version(s) of scipy tested to work with MDOlab tools is ``1.2.2``.
-
-   Scipy depends on numpy
-
 Scipy is required for several packages including :ref:`pyoptsparse`, :ref:`pygeo` and certain
 functionality in pytacs and :ref:`pyspline`.
 It is installed with::
 
-   pip install --user --no-cache scipy==1.2.2
+   pip install scipy==1.2.1 --user --no-cache
 
 .. note::
    On a cluster, most likely numpy and scipy will already be
@@ -430,7 +425,7 @@ mpi4py is the Python wrapper for MPI. This is required for
 **all** parallel MDOlab codes.
 It is installed with::
 
-   pip install --user --no-cache mpi4py==3.0.2
+   pip install mpi4py==3.0.2 --user --no-cache
 
 .. NOTE::
    Some function usages have changed in newer versions of mpi4py. Check the `release <https://github.com/mpi4py/mpi4py/blob/master/CHANGES.rst>`_ to see the modifications that might be requried in the code.
@@ -464,7 +459,7 @@ Simple install with pip
 
 It is installed with::
 
-   pip install --user --no-cache petsc4py==3.11.0
+   pip install petsc4py==3.11.0 --user --no-cache
 
 Advanced install (Multiple PETSc architectures needed)
 ******************************************************

--- a/installInstructions/installFromScratch.rst
+++ b/installInstructions/installFromScratch.rst
@@ -1,8 +1,5 @@
 .. Instructions on how to set up a computer from scratch and be able to 
    run the aero_runs/aero_opt/as_runs/as_opt
-   Author: Eirikur Jonsson (eirikurj@umich.edu)
-   Modifed: C.A.(Sandy) Mader (cmader@umich.edu)
-    
 
 .. _installFromScratch:
 

--- a/tutorials/createSphinxDocs.rst
+++ b/tutorials/createSphinxDocs.rst
@@ -1,6 +1,5 @@
 .. Instructions on how to set up create a new documentation site for an
    existing repository
-   Author: Eirikur Jonsson (eirikurj@umich.edu)
 
 
 .. _createSphinxDocs:

--- a/tutorials/gridRefinementStudy.rst
+++ b/tutorials/gridRefinementStudy.rst
@@ -1,5 +1,4 @@
 .. Standard method of doing a grid refinement study.
-   Author: Nick Bons (nbons@umich.edu)
 
 
 .. _gridRefinementStudy:

--- a/tutorials/tapenadeTips.rst
+++ b/tutorials/tapenadeTips.rst
@@ -1,5 +1,5 @@
-.. Some helpful tips or common pitfalls when using Tapenade to differentiate code. Please add or modify as you see fit.
-   Author: John Jasa (johnjasa@umich.edu)
+.. Some helpful tips or common pitfalls when using Tapenade to differentiate code.
+Please add or modify as you see fit.
 
 
 .. _tapenadeTips:

--- a/tutorials/tecplotTipsAndTricks.rst
+++ b/tutorials/tecplotTipsAndTricks.rst
@@ -1,5 +1,4 @@
 .. Various tips and trick using tecplot. Most are small features that might improve the user experience.
-   Author: Eirikur Jonsson (eirikurj@umich.edu)
 
 
 .. _tecplotTipsAndTricks:

--- a/tutorials/uploadingToBox.rst
+++ b/tutorials/uploadingToBox.rst
@@ -1,5 +1,4 @@
 .. Instructions on how to set up an FTP client to upload data to box.com
-   Author: Eirikur Jonsson (eirikurj@umich.edu)
 
 
 .. _uploadingToBox:


### PR DESCRIPTION
Some more fixes:
- updated package versions
- removed flux page from index
- removed the `download-fblaslapack` option for PETSc, instead recommending a separate system package install for those
- updated some configure option names, such as fortran binding vs interface, and passing yes/no vs. 1/0